### PR TITLE
fix(serial_frame): make sure frame size is greater than 0 when decoding

### DIFF
--- a/src/serial_frame.c
+++ b/src/serial_frame.c
@@ -83,6 +83,14 @@ smp_serial_frame_decoder_process_byte_inframe(SmpSerialFrameDecoder *decoder,
            size_t framesize;
            uint8_t cs;
 
+           /* we should at least have the CRC */
+           if (decoder->frame_offset < 1) {
+               decoder->cbs.error(SMP_SERIAL_FRAME_ERROR_CORRUPTED,
+                       decoder->userdata);
+               decoder->state = SMP_SERIAL_FRAME_DECODER_STATE_WAIT_HEADER;
+               break;
+           }
+
            /* framesize is without the CRC */
            framesize = decoder->frame_offset - 1;
 


### PR DESCRIPTION
Otherwise, an incoming payload with only a START_BYTE and an END_BYTE
will cause the decoder to perform an out of bound read on the frame
buffer causing a segmentation fault.
This was due to the fact that we relied on the frame offset to compute
the framesize. In this case the frame offset when processing the
END_BYTE is 0. When we compute the framesize, we substract the expected
CRC from the frame: framesize = decoder->frame_offset - 1. In this
particular case, we causes an underflow on framesize which is unsigned.
And then passing it to following functions will causes the out-of-bounds
read.

This commit also add a test for this particular case.