### PR TITLE
arduino: generate libsmp-static.h when exporting lib

### DIFF
--- a/include/libsmp.h
+++ b/include/libsmp.h
@@ -183,7 +183,8 @@ typedef struct
  * @warning using this structure directly is deprecated, use smp_message_new or
  * smp_message_new_from_static to get a SmpMessage object
  */
-typedef struct
+typedef struct SmpMessage SmpMessage;
+struct SmpMessage
 {
     /** The message id */
     uint32_t msgid;
@@ -193,7 +194,7 @@ typedef struct
     size_t capacity;
 
     bool statically_allocated;
-} SmpMessage;
+};
 
 SMP_API SmpMessage *smp_message_new(void);
 SMP_API SmpMessage *smp_message_new_with_id(uint32_t id);

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library provides a simple protocol to exchange message between tw
 category=Communication
 url=https://github.com/ActronikaSAS/libsmp
 architectures=*
+includes=libsmp.h

--- a/src/message.c
+++ b/src/message.c
@@ -23,6 +23,10 @@
 
 #include "config.h"
 
+#ifndef SMP_ENABLE_STATIC_API
+#define SMP_ENABLE_STATIC_API
+#endif
+
 #include "libsmp.h"
 #include "libsmp-private.h"
 #include <stdarg.h>


### PR DESCRIPTION
by copy-pasting the original structure, I think it's not the best
solution but it works for now. Arduino IDE compatibility was broken
since this file was added.