### PR TITLE
message: fix overflow when checking for string length in encode_value()

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -322,8 +322,8 @@ static ssize_t smp_message_encode_value(const SmpValue *value, uint8_t *buffer)
                 smp_write_int64(buffer, value->value.i64);
                 break;
             case SMP_TYPE_STRING: {
-                int len = strlen(value->value.cstring);
-                if (len + 1 > (int) UINT16_MAX) {
+                size_t len = strlen(value->value.cstring);
+                if (len > (UINT16_MAX - 1)) {
                     /* string too long */
                     return 0;
                 }


### PR DESCRIPTION
Casting UINT16_MAX to int when checking string length can overflow when
sizeof(int) is 2, like on AVR-based platform, making the string always
too big. So this commit changes the condition to directly use a size_t
as strlen return is size_t and substract nul byte to UINT16_MAX instead
of adding it to string length to avoid further overflow.

This bug was introduced by commit 3d89d27c0c0390c1c22292ede462730f93e2d9dc
(fix(message): cast UINT16_MAX to int in comparison).